### PR TITLE
Update Home Assistant driver test docs

### DIFF
--- a/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
+++ b/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
@@ -178,9 +178,18 @@ Upon completion, initiate the platform driver. Utilize the listener agent to ver
 
 Running Tests
 +++++++++++++++++++++++
-To run tests on the VOLTTRON home assistant driver you need to create a helper in your home assistant instance. This can be done by going to **Settings > Devices & services > Helpers > Create Helper > Toggle**. Name this new toggle **volttrontest**. After that run the pytest from the root of your VOLTTRON file.
+To run the VOLTTRON Home Assistant driver tests, first create a helper toggle named **volttrontest** in your Home Assistant instance. You can create it from **Settings > Devices & services > Helpers > Create Helper > Toggle**.
+
+You must also update the test configuration values in ``services/core/PlatformDriverAgent/tests/test_home_assistant.py``:
+
+- ``HOMEASSISTANT_TEST_IP``: IP address or hostname of your Home Assistant instance
+- ``ACCESS_TOKEN``: Home Assistant long-lived access token
+- ``PORT``: Port used by your Home Assistant instance
+
+After setting those values, run pytest from the root of your VOLTTRON repository:
 
 .. code-block:: bash
-    pytest volttron/services/core/PlatformDriverAgent/tests/test_home_assistant.py
+
+   pytest services/core/PlatformDriverAgent/tests/test_home_assistant.py
 
 If everything works, you will see 6 passed tests.


### PR DESCRIPTION
## What changed

Updated the Home Assistant driver documentation to correct the pytest path and document the required test setup.

## Why

The previous test command used a path that does not match the current repository layout. The docs also did not mention that the Home Assistant test requires local test configuration values to be set before running.

## Details

- corrected the pytest path to `services/core/PlatformDriverAgent/tests/test_home_assistant.py`
- added the required Home Assistant setup step to create a helper toggle named `volttrontest`
- documented the required test configuration values in `test_home_assistant.py`:
  - `HOMEASSISTANT_TEST_IP`
  - `ACCESS_TOKEN`
  - `PORT`

## Impact

This makes the test instructions runnable from the repo root and clarifies the setup required before executing the Home Assistant driver tests.

## Validation

- verified the test file exists at `services/core/PlatformDriverAgent/tests/test_home_assistant.py`
- verified the test code requires `HOMEASSISTANT_TEST_IP`, `ACCESS_TOKEN`, and `PORT`
- no automated tests were run because this is a documentation-only change
